### PR TITLE
remove use of dynamic strict in the es mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marketplace_api",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "The API allowing to manage Nevermined Marketplace common functionalities",
   "main": "main.ts",
   "scripts": {

--- a/src/assets/asset.mappings.ts
+++ b/src/assets/asset.mappings.ts
@@ -1,7 +1,6 @@
 import { MappingProperty } from '@elastic/elasticsearch/api/types';
 
 export const AssetMappings: MappingProperty = {
-  dynamic: 'strict',
   properties: {
     '@context': {
       type: 'text',
@@ -65,7 +64,6 @@ export const AssetMappings: MappingProperty = {
       },
     },
     proof: {
-      dynamic: true,
       properties: {
         created: {
           type: 'date',
@@ -149,7 +147,6 @@ export const AssetMappings: MappingProperty = {
       },
     },
     service: {
-      dynamic: true,
       properties: {
         creator: {
           type: 'text',
@@ -718,10 +715,10 @@ export const AssetMappings: MappingProperty = {
       },
     },
     verifiableCredential: {
-      dynamic: true,
+      type: 'object',
     },
     updated: {
-      dynamic: true,
+      type: 'date',
     },
   },
 };


### PR DESCRIPTION


## Description

- The use of `dynamic='strict'` creating too many issues. Disabling
- bumped version to v0.2.0

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

